### PR TITLE
Add cleanup

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,4 @@
 {
-  "presets": ["@babel/preset-env"]
+  "presets": ["@babel/preset-env"],
+  "plugins": ["@babel/plugin-transform-react-jsx", "@babel/plugin-transform-runtime"]
 }

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+    testPathIgnorePatterns: ['/node_modules/', '/public/'],
+    transform: {
+        '\\.(js|ts|tsx)?$': 'babel-jest',
+      },
+}

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Simple Crank.js testing utilities that encourage good testing practices",
   "main": "dist/index.js",
   "scripts": {
-    "build": "rimraf dist && babel src --out-dir dist"
+    "build": "rimraf dist && babel src --out-dir dist",
+    "test": "jest"
   },
   "license": "MIT",
   "files": [
@@ -18,7 +19,10 @@
     "@babel/cli": "^7.8.4",
     "@babel/preset-env": "^7.9.5",
     "babel-jest": "^25.4.0",
-    "rimraf": "^3.0.2"
+    "rimraf": "^3.0.2",
+    "@babel/plugin-transform-react-jsx": "^7.9.4",
+    "@babel/plugin-transform-runtime": "^7.9.0",
+    "jest": "^25.4.0"
   },
   "peerDependencies": {
     "@bikeshaving/crank": "0.x"

--- a/src/__tests__/cleanup.test.js
+++ b/src/__tests__/cleanup.test.js
@@ -1,0 +1,16 @@
+/** @jsx createElement */
+import {createElement} from "@bikeshaving/crank";
+import { render, cleanup } from "../index";
+
+describe("cleanup()", () => {
+  it("should clear the document", async () => {
+    function Test() {
+        return <div>Testing cleanup</div>
+    }
+
+    render(<Test />);
+    expect(document.body.innerHTML).toBe("<div><div>Testing cleanup</div></div>");
+    await cleanup();
+    expect(document.body.innerHTML).toBe("");
+  });
+});

--- a/src/index.js
+++ b/src/index.js
@@ -7,6 +7,17 @@ import {
 
 const mountedContainers = new Set()
 
+function cleanup() {
+  mountedContainers.forEach(cleanupContainer);
+}
+
+function cleanupContainer(container) {
+  if (container.parentNode === document.body) {
+    document.body.removeChild(container)
+  }
+  mountedContainers.delete(container);
+}
+
 function render(ui,
   {
     container,
@@ -32,7 +43,6 @@ function render(ui,
   return {
     container,
     baseElement,
-    // TODO: implement cleanup
     debug: (el = baseElement, maxLength, options) =>
       Array.isArray(el)
         ? // eslint-disable-next-line no-console
@@ -45,4 +55,4 @@ function render(ui,
 
 // just re-export everything from dom-testing-library
 export * from '@testing-library/dom'
-export { render  }
+export { render , cleanup }


### PR DESCRIPTION
I added a minimal `cleanup()` implementation that removes any mounted containers. Next steps might be to see if it's worth adding something similar to `react-testing-library` to autorun cleanup after every test, but I decided to leave that for now.

I added a minimal jest configuration for testing this function and for future tests.